### PR TITLE
beforeException on Application getModule

### DIFF
--- a/phalcon/application.zep
+++ b/phalcon/application.zep
@@ -120,7 +120,8 @@ abstract class Application extends Injectable implements EventsAwareInterface
 		var module;
 
 		if !fetch module, this->_modules[name] {
-			throw new Exception("Module '" . name . "' isn't registered in the application container");
+			exception = new Exception("Module '" . name . "' isn't registered in the application container");
+ 			this->_handleException(exception);
 		}
 
 		return module;
@@ -142,6 +143,22 @@ abstract class Application extends Injectable implements EventsAwareInterface
 	{
 		return this->_defaultModule;
 	}
+	
+	/**
+ 	 * Handles a user exception
+ 	 */
+ 	protected function _handleException(<\Exception> exception)
+ 	{
+ 		var eventsManager;
+ 		let eventsManager = <ManagerInterface> this->_eventsManager;
+ 		if typeof eventsManager == "object" {
+ 			if eventsManager->fire("application:beforeException", this, exception) === false {
+				return false;
+ 			} else {
+ 				throw exception;
+ 			}
+ 		}
+ 	}
 
 	/**
 	 * Handles a request


### PR DESCRIPTION
For multi-module applications it is possible to attach a beforeException event to the Application.

Hello!

* Type: bug fix | new feature | code quality | documentation
* Link to issue:

**In raising this pull request, I confirm the following (please check boxes):**

- [ ] I have read and understood the [Contributing Guidelines](https://github.com/phalcon/cphalcon/blob/master/CONTRIBUTING.md)?
- [ ] I have checked that another pull request for this purpose does not exist.
- [ ] I wrote some tests for this PR.

Small description of change:

Thanks

