### PR TITLE
beforeException event on Application getModule

### DIFF
--- a/phalcon/application.zep
+++ b/phalcon/application.zep
@@ -112,19 +112,37 @@ abstract class Application extends Injectable implements EventsAwareInterface
 		return this->_modules;
 	}
 
-	/**
+		/**
 	 * Gets the module definition registered in the application via module name
 	 */
 	public function getModule(string! name) -> array | object
 	{
-		var module;
+		var module, exception;
 
 		if !fetch module, this->_modules[name] {
-			throw new Exception("Module '" . name . "' isn't registered in the application container");
+			let exception = new Exception("Module '" . name . "' isn't registered in the application container");
+  			this->_handleException(exception);
 		}
 
 		return module;
 	}
+	
+	/**
+	 * Handles a user exception
+	 */
+	protected function _handleException(<\Exception> exception)
+	{
+		var eventsManager;
+		let eventsManager = <ManagerInterface> this->_eventsManager;
+		if typeof eventsManager == "object" {
+			if eventsManager->fire("application:beforeException", this, exception) === false {
+				return false;
+			}
+			
+			throw exception;
+		}
+	}
+
 
 	/**
 	 * Sets the module name to be used if the router doesn't return a valid module


### PR DESCRIPTION
Hello!

* Type: new feature
* Link to issue: https://github.com/phalcon/cphalcon/pull/12733

**In raising this pull request, I confirm the following (please check boxes):**

- [x] I have read and understood the [Contributing Guidelines](https://github.com/phalcon/cphalcon/blob/master/CONTRIBUTING.md)?
- [x] I have checked that another pull request for this purpose does not exist.
- [ ] I wrote some tests for this PR.

Small description of change:

With this patch it's possible to attach a `beforeException` event to the Application.
The default behaviour is the same (throw exception) if not event listener is set.
Thanks